### PR TITLE
Add AngebotGesamtkonditionen

### DIFF
--- a/README.md
+++ b/README.md
@@ -416,11 +416,11 @@ Es gibt die Scalare `Euro` und `Prozent`, die jeweils Wrapper für BigDecimal si
 ## Angebot
 
     {
-        gesamtkonditionen: Gesamtkonditionen
+        gesamtkonditionen: AngebotGesamtkonditionen
         ratenkredit: Ratenkredit
     }
 
-### Gesamtkonditionen
+### Gesamtkonditionen | AngebotGesamtkonditionen
 
     {
         effektivzins: Prozent,


### PR DESCRIPTION
Da in den Schaufensterkonditionen die Gesamtkonditionen gleich der AngebotGesamtkonditionen sind, habe ich mich jetzt  für diese Schreibweise entschiedne.

Gibt es da Einwände?